### PR TITLE
Fixing up hashable error in looking through config

### DIFF
--- a/custom_components/ha_transportnsw/__init__.py
+++ b/custom_components/ha_transportnsw/__init__.py
@@ -137,7 +137,7 @@ async def async_setup(hass: HomeAssistant, config):
 
     # Iterate through and capture the data for each existing entry, grouped by API key
     # These will be converted to a single entry per API key, with multiple subentries
-    if ['sensor'] in config:
+    if 'sensor' in config:
         for sensor in config['sensor']:
             if sensor['platform'] == DOMAIN:
                 api_key, subentry_data = await get_migration_data(hass, sensor)


### PR DESCRIPTION
Found that this one little fix should ensure that it can find the `sensor` list in the existing config. This should stop the error from https://github.com/andystewart999/ha_transportnsw/issues/12 and I tested it locally and it appears to be working for me :) 